### PR TITLE
Refactor: use monadic operators and prefer `NonZeroU64` for seconds

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,21 +24,12 @@ fn main() {
     env_logger::init();
     debug!("Jiggle started.");
     let mouse_controller = Mouse::new();
-    let sleep_duration = match opt.seconds {
-        Some(v) => v,
-        None => {
-            let sleep_duration_result = env::var("JIGGLE_SLEEP");
-            let default_sleep = 10; // 10 seconds
-            let val: u64 = match sleep_duration_result {
-                Ok(v) => match v.to_string().parse::<u64>() {
-                    Ok(x) => x,
-                    Err(_) => default_sleep,
-                },
-                Err(_) => default_sleep,
-            };
-            val
-        }
-    };
+    let sleep_duration = opt.seconds.unwrap_or_else(|| {
+        env::var("JIGGLE_SLEEP")
+            .ok()
+            .and_then(|var| var.parse().ok())
+            .unwrap_or(10) // 10 seconds...
+    });
     debug!("Sleep duration is set to {sleep_duration}s.");
     loop {
         let old_position = mouse_controller.get_position().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,8 +44,8 @@ fn main() {
             y: old_position.y + 1,
         };
         debug!("Moving the mouse a tiny bit.");
-        _ = mouse_controller.move_to(new_position.x, new_position.y);
-        _ = mouse_controller.move_to(old_position.x, old_position.y);
+        mouse_controller.move_to(new_position.x, new_position.y).unwrap();
+        mouse_controller.move_to(old_position.x, old_position.y).unwrap();
         debug!("Sleeping for {sleep_duration}s.");
         thread::sleep(Duration::new(sleep_duration, 0));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,6 @@ fn main() {
         mouse_controller.move_to(new_position.x, new_position.y).unwrap();
         mouse_controller.move_to(old_position.x, old_position.y).unwrap();
         debug!("Sleeping for {sleep_duration}s.");
-        thread::sleep(Duration::new(sleep_duration, 0));
+        thread::sleep(Duration::from_secs(sleep_duration));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use log::debug;
-use std::{env, thread, time::Duration};
+use std::{env, num::NonZeroU64, thread, time::Duration};
 use structopt::StructOpt;
 
 use mouse_rs::{types::Point, Mouse};
@@ -15,7 +15,7 @@ struct Opt {
     /// Seconds to wait before moving your mouse.
     /// default: 10s, can also be set by using the `JIGGLE_SLEEP`
     /// environment variable.
-    seconds: Option<u64>,
+    seconds: Option<NonZeroU64>,
 }
 
 fn main() {
@@ -23,13 +23,19 @@ fn main() {
     let opt = Opt::from_args();
     env_logger::init();
     debug!("Jiggle started.");
+
     let mouse_controller = Mouse::new();
-    let sleep_duration = opt.seconds.unwrap_or_else(|| {
-        env::var("JIGGLE_SLEEP")
-            .ok()
-            .and_then(|var| var.parse().ok())
-            .unwrap_or(10) // 10 seconds...
-    });
+    let sleep_duration = opt
+        .seconds
+        .or_else(|| {
+            env::var("JIGGLE_SLEEP")
+                .ok()
+                .and_then(|var| var.parse().ok())
+                .and_then(NonZeroU64::new)
+        })
+        .map(NonZeroU64::get)
+        .unwrap_or(10);
+
     debug!("Sleep duration is set to {sleep_duration}s.");
     loop {
         let old_position = mouse_controller.get_position().unwrap();


### PR DESCRIPTION
Hello there! Fun little project here. Figured that a little bit of cleanup would be appreciated. In this PR:

* I transformed the long, nested `match` statements into their monadic counterparts so that the control flow is more "flat" and "linear", so to speak.
* I replaced the `seconds` option to take in an `Option<NonZeroU64>` instead of an `Option<u64>`. This allows the compiler to optimize for memory layout. The former ensures that `seconds` is represented in memory as if it were a plain `u64` (which is not the case for the latter). Moreover, it doesn't make sense to provide zero delay, anyway. 😅
* Finally, I ensured that the program panics if it can't move the mouse. I figured that this would be the intentional behavior so that there are no surprises in case errors do arise.

That is all. Thanks! 🎉